### PR TITLE
fix: content widths and clipboard colors

### DIFF
--- a/src/_includes/assets/scripts/web-components/docs-demos.ts
+++ b/src/_includes/assets/scripts/web-components/docs-demos.ts
@@ -4,10 +4,14 @@ import "../prism/prism.js";
 import "./clipboard-copy-icon.js";
 
 const css = `
-  :host,
-    .demo {
-      display: flex;
-      flex-direction: column;
+  docs-demos {
+    width: 100%;
+  }
+
+  docs-demos,
+  .demo {
+    display: flex;
+    flex-direction: column;
   }
 
   h3 clipboard-copy-icon {
@@ -50,9 +54,12 @@ const css = `
     background: var(--docs-secondary-color);
   }
 
-  clipboard-copy-icon {
+  #content docs-demos .code-header clipboard-copy-icon {
     --button-background-color: transparent;
     --message-text-color: var(--zui-gray-200);
+    margin-left: 0;
+    opacity: 1;
+    transition: background 0.3s ease;
   }
 
   .demo:not(:first-of-type) {

--- a/src/_includes/assets/styles/pages/component-single.scss
+++ b/src/_includes/assets/styles/pages/component-single.scss
@@ -25,9 +25,13 @@ zui-spinner:not([active]) {
     display: none;
   }
 
-  .usage {
-      width: calc(100% - 200px); /* subtracts quick-links width */
-      max-width: rem(1000);
+  #demos,
+  #usage .documentation {
+    width: calc(100% - 200px); /* subtracts quick-links width */
+  }
+
+  #usage .documentation {
+    max-width: rem(1000);
   }
   
   h1.component-header {

--- a/src/_includes/layouts/component.njk
+++ b/src/_includes/layouts/component.njk
@@ -77,7 +77,7 @@ layout: base
     <quick-links query="#demos h1, #demos h2, #demos h3, #demos h4"></quick-links>
   </div>
   <div id="usage" class="zui row align-start is-hidden">
-    <div>{{ content | safe }}</div>
+    <div class="documentation">{{ content | safe }}</div>
     <quick-links query="#usage h1, #usage h2, #usage h3, #usage h4"></quick-links>
   </div>
 </section>


### PR DESCRIPTION
### Fixes

- Component demos code snippets overflow issues
- Component demos code snippet copy-to-clipboard opacity override
- Component usage content width set to max of 1000px