### PR TITLE
feat: include systems as part of Netlify collections

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -9,8 +9,17 @@ publish_mode: editorial_workflow
 media_folder: "static/images" # Media files will be stored in the repo under images/uploads
 
 collections:
+  - name: "application_framework"
+    label: "Application Framework"
+    folder: "src/_areas/application-framework"
+    create: true
+    fields:
+      - {label: "Layout", name: "layout", widget: "hidden", default: "documentation"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Subtitle", name: "subtitle", widget: "string"}
+      - {label: "Body", name: "body", widget: "markdown"}
   - name: "application_framework_components"
-    label: "Application Framework Component"
+    label: "Application Framework / Components"
     folder: "src/_areas/application-framework/components"
     create: true
     fields:
@@ -22,7 +31,7 @@ collections:
       - {label: "Main component name", name: "mainComponentName", widget: "string"}
       - {label: "Included elements", name: "includedElements", widget: "list", default: []}
   - name: "application_framework_developers"
-    label: "Application Framework Developers"
+    label: "Application Framework / Developers"
     folder: "src/_areas/application-framework/developers"
     create: true
     fields:
@@ -43,20 +52,29 @@ collections:
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "Collection", name: "collection", widget: "select", options: ["Design", "Engineering", "Research"]}
       - { label: "Tags", name: "tags", widget: "list", default: [] }
+  - name: "design_system"
+    label: "Design System"
+    folder: "src/_areas/design-system"
+    create: true
+    fields:
+      - {label: "Layout", name: "layout", widget: "hidden", default: "documentation"}
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Subtitle", name: "subtitle", widget: "string"}
+      - {label: "Body", name: "body", widget: "markdown"}
   - name: "design_system_components"
-    label: "Design System Component"
+    label: "Design System / Components"
     folder: "src/_areas/design-system/components"
     create: true
     fields:
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Subtitle", name: "subtitle", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
-      - {label: "API Schema", name: "api", widget: "string"}
-      - {label: "Demo URI", name: "demo", widget: "string"}
-      - {label: "Main component name", name: "mainComponentName", widget: "string"}
+      - {label: "API Schema", name: "api", widget: "string", default: "https://cdn.zywave.com/@zywave/zui-[PACKAGENAME]@next/dist/custom-elements.json"}
+      - {label: "Demo URI", name: "demo", widget: "string", default: "https://cdn.zywave.com/@zywave/zui-[PACKAGENAME]@next/demo/index.html"}
+      - {label: "Main component name", name: "mainComponentName", widget: "string", default: "zui-[PACKAGENAME]"}
       - {label: "Included elements", name: "includedElements", widget: "list", default: []}
   - name: "design_system_developers"
-    label: "Design System Developers"
+    label: "Design System / Developers"
     folder: "src/_areas/design-system/developers"
     create: true
     fields:
@@ -65,7 +83,7 @@ collections:
       - {label: "Subtitle", name: "subtitle", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "design_system_patterns"
-    label: "Design System Pattern"
+    label: "Design System / Patterns"
     folder: "src/_areas/design-system/patterns"
     create: true
     fields:
@@ -74,7 +92,7 @@ collections:
       - {label: "Subtitle", name: "subtitle", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "design_system_visuals"
-    label: "Design System Visuals"
+    label: "Design System / Visuals"
     folder: "src/_areas/design-system/visuals"
     create: true
     fields:
@@ -83,7 +101,7 @@ collections:
       - {label: "Subtitle", name: "subtitle", widget: "string"}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "design_system_voice-and-tone"
-    label: "Design System Voice and Tone"
+    label: "Design System / Voice and Tone"
     folder: "src/_areas/design-system/voice-and-tone"
     create: true
     fields:


### PR DESCRIPTION
The about pages for Design System and Application Framework are not part of the Netlify CMS collections, so hoping this will surface them there.