### PR TITLE
feat: add <docs-note> wc, basic setup

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -23,8 +23,9 @@
         const docsCustomElementsFiles = [
           "/js/web-components/docs-do.js",
           "/js/web-components/docs-do-not.js",
-          "/js/web-components/docs-spacer.js",
-          "/js/web-components/docs-grid.js"
+          "/js/web-components/docs-grid.js",
+          "/js/web-components/docs-note.js",
+          "/js/web-components/docs-spacer.js"
         ];
         
         docsCustomElementsFiles.forEach(file => {

--- a/src/_includes/assets/scripts/web-components/docs-note.ts
+++ b/src/_includes/assets/scripts/web-components/docs-note.ts
@@ -1,0 +1,32 @@
+export class DocsNote extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({mode: 'open'});
+        const templateStr = `
+            <style>
+                :host {
+                    display: block;
+                    margin-bottom: 1rem;
+                }
+                div {
+                    display: inline-block;
+                    padding: 1.25rem 1.875rem;
+                    background-color: hsl(167deg 74% 34% / 20%);
+                    color: #505A61;
+                    border-radius: 5px;
+                }
+                ::slotted(a) {
+                    color: #17987C;
+                }
+            </style>
+            <div>
+                <slot></slot>
+            </div>
+        `;
+        const template = document.createElement('template');
+        template.innerHTML = templateStr;
+        this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+}
+
+window.customElements.define('docs-note', DocsNote);

--- a/src/_includes/layouts/component.njk
+++ b/src/_includes/layouts/component.njk
@@ -21,6 +21,7 @@ layout: nav-base
 <script type="module" src="{{ "js/web-components/docs-do-not.js" | url }}"></script>
 <script type="module" src="{{ "js/web-components/docs-spacer.js" | url }}"></script>
 <script type="module" src="{{ "js/web-components/docs-grid.js" | url }}"></script>
+<script type="module" src="{{ "js/web-components/docs-note.js" | url }}"></script>
 
 {% if not api %}
 <span class="component-status not-available" title="While documented, this component may not be available in the Toolkit.">Not implemented</span>


### PR DESCRIPTION
- Basic support for `<docs-note>` WC 
![image](https://user-images.githubusercontent.com/6565619/148984489-b14935b5-1729-4068-92c4-f0cc8bf6192d.png)

XD mock/spec link:
https://xd.adobe.com/view/97e7c0c4-050d-4f13-9efb-ce6108262e19-c2b4/screen/17bf11fb-ba0d-4baf-a99c-82f76c51462e/
