### PR TITLE
zui-tabs fixed

### DIFF
--- a/src/_includes/assets/styles/layout/component.scss
+++ b/src/_includes/assets/styles/layout/component.scss
@@ -1,5 +1,5 @@
 // fouc styles for zui-tabs
-@import "https://cdn.zywave.com/@zywave/zui-tabs@latest/dist/css/zui-tabs.fouc.min.css";
+@import "https://cdn.zywave.com/@zywave/zui-tabs@latest/dist/css/zui-tabs.fouc.css";
 
 zui-tabs {
   margin-bottom: rem(48);
@@ -8,6 +8,10 @@ zui-tabs {
   a {
     &:active {
       text-decoration: none;
+    }
+
+    &:focus {
+      outline: 0;
     }
 
     &:-webkit-any-link {

--- a/src/_includes/assets/styles/layout/component.scss
+++ b/src/_includes/assets/styles/layout/component.scss
@@ -4,6 +4,7 @@
 zui-tabs {
   margin-bottom: rem(48);
   --zui-tabs-color: var(--docs-secondary-color);
+  --zui-tabs-fouc-scroll-button-space: 0;
 
   a {
     &:active {

--- a/src/_includes/layouts/component.njk
+++ b/src/_includes/layouts/component.njk
@@ -34,7 +34,7 @@ layout: side-nav-base
 {% if subtitle %} <h2 class="component-subheader">{{ subtitle }}</h2> {% endif %}
 
 <nav class="zui row">
-  <zui-tabs selected="-1">
+  <zui-tabs>
     {% for tab in tabs %}
       <zui-tab id="tab-{{ tab | slug }}">
         <a href="{{ page.url | componentTabHref(tab) | url }}" class="zui text-decoration-none">{{ tab }}</a>


### PR DESCRIPTION
- remove tabs selected value of `-1`,  was botching which tab should be selected/underlined, tabs defaults to `<zui-tabs selected="0"` without passing a val
- fix link to tabs' fouc styles
- set var for FOUC so renders FOUC closer to final appearance
- remove outline when clicking an `<a>` within a `<zui-tab>`, should not have this effect