### PR TITLE
fix: force code blocks with long lines to wrap

### DIFF
--- a/src/_includes/assets/styles/components/code-prismjs.scss
+++ b/src/_includes/assets/styles/components/code-prismjs.scss
@@ -12,7 +12,7 @@
        font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
        font-size: 1em;
        text-align: left;
-       white-space: pre;
+       white-space: pre-wrap;
        word-spacing: normal;
        word-break: normal;
        word-wrap: normal;

--- a/src/_includes/assets/styles/layout/base.scss
+++ b/src/_includes/assets/styles/layout/base.scss
@@ -1,3 +1,7 @@
+pre, code {
+  white-space: pre-wrap;
+}
+
 main {
   width: 100%;
   margin: 0 auto;


### PR DESCRIPTION
Before:  
![image](https://user-images.githubusercontent.com/3359330/195447664-ef479950-b886-4280-bacd-8138572145ef.png)

After:  
![image](https://user-images.githubusercontent.com/3359330/195447693-f0a6ccb5-3b04-4fc1-8ae5-6f23e6c666ee.png)
