### PR TITLE
chore: fix content widths

### DIFF
--- a/src/_includes/assets/scripts/web-components/quick-links.ts
+++ b/src/_includes/assets/scripts/web-components/quick-links.ts
@@ -11,12 +11,6 @@ const css = `
         width: 200px;
         transition: margin 100ms ease-in-out;
     }
-
-    @media screen and (min-width: 64em) {
-      :host {
-        margin: 0 0 0 1.875rem; /* 30 / 16 */
-      }
-    }
     
     @media screen and (max-width: 45em) {
       :host {
@@ -26,7 +20,7 @@ const css = `
   
     @media screen and (min-width: 64em) {
       :host {
-        margin: 0 0 0 2.5rem; /* 40 / 16 */
+        margin: 0 0 0 1.875rem; /* 30 / 16 */
       }
     }
   

--- a/src/_includes/assets/styles/components/side-nav.scss
+++ b/src/_includes/assets/styles/components/side-nav.scss
@@ -14,6 +14,7 @@ nav.side-nav {
   background-color: var(--docs-primary-color);
   border-right: 1px solid #5c4f4f;
   box-sizing: border-box;
+  transition: width 100ms ease-in-out, padding 100ms ease-in-out;
 
   @media screen and (min-width: 64em) {
     width: rem(250);

--- a/src/_includes/assets/styles/layout/base.scss
+++ b/src/_includes/assets/styles/layout/base.scss
@@ -1,3 +1,14 @@
+body.documentation main .content-wrapper,
+body.blog main .content-wrapper {
+  width: 100%;
+  max-width: rem(1430);
+}
+
+body.blog main .content-wrapper {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 pre, code {
   white-space: pre-wrap;
 }
@@ -10,12 +21,17 @@ main {
     width: 100%;
 
     .content-wrapper {
-      width: calc(100% - #{rem(350)});
+      width: 100%;
+
+      // @media screen and (min-width: 120em) {
+      //   width: calc(100% - #{rem(350)});
+      // }
     }
   }
 
   .content-wrapper {
     margin-top: rem(107);
+    transition: width 100ms ease-in-out, padding 100ms ease-in-out, margin 100ms ease-in-out;
 
     @media (min-width: 58.4375rem) { // 935px
       margin-top: rem(61);

--- a/src/_includes/assets/styles/layout/base.scss
+++ b/src/_includes/assets/styles/layout/base.scss
@@ -1,7 +1,7 @@
 body.documentation main .content-wrapper,
 body.blog main .content-wrapper {
   width: 100%;
-  max-width: rem(1430);
+  max-width: rem(1430); /* content + quick links width */
 }
 
 body.blog main .content-wrapper {
@@ -22,10 +22,6 @@ main {
 
     .content-wrapper {
       width: 100%;
-
-      // @media screen and (min-width: 120em) {
-      //   width: calc(100% - #{rem(350)});
-      // }
     }
   }
 

--- a/src/_includes/assets/styles/layout/component.scss
+++ b/src/_includes/assets/styles/layout/component.scss
@@ -38,7 +38,7 @@ h2.component-subheader {
     display: none;
   }
 
-  #api, #demos, #usage {
+  #api, #demos, #usage, #usage .documentation {
     width: 100%;
   }
 

--- a/src/_includes/assets/styles/layout/component.scss
+++ b/src/_includes/assets/styles/layout/component.scss
@@ -38,13 +38,12 @@ h2.component-subheader {
     display: none;
   }
 
-  #demos,
-  #usage .documentation {
-    width: calc(100% - 200px); /* subtracts quick-links width */
+  #api, #demos, #usage {
+    width: 100%;
   }
 
-  #usage .documentation {
-    max-width: rem(1000);
+  #demos, #usage {
+    max-width: rem(1250);
   }
 
   clipboard-copy-icon {

--- a/src/_includes/assets/styles/layout/component.scss
+++ b/src/_includes/assets/styles/layout/component.scss
@@ -43,7 +43,7 @@ h2.component-subheader {
   }
 
   #demos, #usage {
-    max-width: rem(1250);
+    max-width: rem(1250); /* content + quick links width */
   }
 
   clipboard-copy-icon {

--- a/src/_includes/assets/styles/layout/component.scss
+++ b/src/_includes/assets/styles/layout/component.scss
@@ -42,6 +42,10 @@ h2.component-subheader {
     width: 100%;
   }
 
+  #api {
+    max-width: rem(1400);
+  }
+
   #demos, #usage {
     max-width: rem(1250); /* content + quick links width */
   }

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -55,7 +55,11 @@
 	<link rel="stylesheet" href="https://cdn.zywave.com/@algolia/algoliasearch-netlify-frontend@1.0.8/dist/algoliasearchNetlify.css" />
 </head>
 
+{% if layout === 'documentation' or 'blog' %}
+<body class="zui row {{ pageType }} {{ layout }}">
+{% else %}
 <body class="zui row {{ pageType }}">
+{% endif %}
 	<script async src="https://cdn.zywave.com/es-module-shims@1.0.0/dist/es-module-shims.js"></script>
 	{{ content | safe }}
 	{% include "components/feedback.njk" %}

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -14,7 +14,7 @@ layout: no-side-nav-base
 <script type="module" src="{{ "js/web-components/docs-grid.js" | url }}"></script>
 
 
-<article class="zui content-area slim">
+<article>
   <zui-breadcrumbs>
     <zui-breadcrumb>
       <a href="{{ '/blog/' | url }}">Blog</a>


### PR DESCRIPTION
## Changes

All content widths are now fluid!

- Increased blog post content width (excluding table of contents) from 900px to 1000px for screen sizes wider than 1280px
- Components layout changes
  - Increased API tab's width to 1400px for screen sizes wider than 1280px
  - Increased Demo tab content width (excluding table of contents) to 1000px for screen sizes wider than 1280px
  - Increased Usage tab content width (excluding table of contents) to 1000px for screen sizes wider than 1280px
- Added some CSS transitions to make padding, margin, and width changes less jarring